### PR TITLE
JoinType.Actionable method and related logic

### DIFF
--- a/example/app/internal/model/schema.pqt.go
+++ b/example/app/internal/model/schema.pqt.go
@@ -1369,7 +1369,7 @@ func (i *PackageIterator) Package() (*PackageEntity, error) {
 		return nil, err
 	}
 	var prop []interface{}
-	if i.expr.JoinCategory != nil && i.expr.JoinCategory.Fetch {
+	if i.expr.JoinCategory != nil && i.expr.JoinCategory.Kind.Actionable() && i.expr.JoinCategory.Fetch {
 		ent.Category = &CategoryEntity{}
 		if prop, err = ent.Category.Props(); err != nil {
 			return nil, err
@@ -1718,13 +1718,13 @@ func (r *PackageRepositoryBase) FindQuery(fe *PackageFindExpr) (string, []interf
 	} else {
 		buf.WriteString(strings.Join(fe.Columns, ", "))
 	}
-	if fe.JoinCategory != nil && fe.JoinCategory.Fetch {
+	if fe.JoinCategory != nil && fe.JoinCategory.Kind.Actionable() && fe.JoinCategory.Fetch {
 		buf.WriteString(", t1.content, t1.created_at, t1.id, t1.name, t1.parent_id, t1.updated_at")
 	}
 	buf.WriteString(" FROM ")
 	buf.WriteString(r.Table)
 	buf.WriteString(" AS t0")
-	if fe.JoinCategory != nil {
+	if fe.JoinCategory != nil && fe.JoinCategory.Kind.Actionable() {
 		joinClause(comp, fe.JoinCategory.Kind, "example.category AS t1 ON t0.category_id=t1.id")
 		if fe.JoinCategory.On != nil {
 			comp.Dirty = true
@@ -1742,7 +1742,7 @@ func (r *PackageRepositoryBase) FindQuery(fe *PackageFindExpr) (string, []interf
 			return "", nil, err
 		}
 	}
-	if fe.JoinCategory != nil && fe.JoinCategory.Where != nil {
+	if fe.JoinCategory != nil && fe.JoinCategory.Kind.Actionable() && fe.JoinCategory.Where != nil {
 		if err := CategoryCriteriaWhereClause(comp, fe.JoinCategory.Where, 1); err != nil {
 			return "", nil, err
 		}
@@ -1834,7 +1834,7 @@ func (r *PackageRepositoryBase) Find(ctx context.Context, fe *PackageFindExpr) (
 			return nil, err
 		}
 		var prop []interface{}
-		if fe.JoinCategory != nil && fe.JoinCategory.Fetch {
+		if fe.JoinCategory != nil && fe.JoinCategory.Kind.Actionable() && fe.JoinCategory.Fetch {
 			ent.Category = &CategoryEntity{}
 			if prop, err = ent.Category.Props(); err != nil {
 				return nil, err
@@ -4802,14 +4802,14 @@ func (i *CommentIterator) Comment() (*CommentEntity, error) {
 		return nil, err
 	}
 	var prop []interface{}
-	if i.expr.JoinNewsByTitle != nil && i.expr.JoinNewsByTitle.Fetch {
+	if i.expr.JoinNewsByTitle != nil && i.expr.JoinNewsByTitle.Kind.Actionable() && i.expr.JoinNewsByTitle.Fetch {
 		ent.NewsByTitle = &NewsEntity{}
 		if prop, err = ent.NewsByTitle.Props(); err != nil {
 			return nil, err
 		}
 		props = append(props, prop...)
 	}
-	if i.expr.JoinNewsByID != nil && i.expr.JoinNewsByID.Fetch {
+	if i.expr.JoinNewsByID != nil && i.expr.JoinNewsByID.Kind.Actionable() && i.expr.JoinNewsByID.Fetch {
 		ent.NewsByID = &NewsEntity{}
 		if prop, err = ent.NewsByID.Props(); err != nil {
 			return nil, err
@@ -5264,16 +5264,16 @@ func (r *CommentRepositoryBase) FindQuery(fe *CommentFindExpr) (string, []interf
 	} else {
 		buf.WriteString(strings.Join(fe.Columns, ", "))
 	}
-	if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Fetch {
+	if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Kind.Actionable() && fe.JoinNewsByTitle.Fetch {
 		buf.WriteString(", t1.content, t1.continue, t1.created_at, t1.id, t1.lead, t1.meta_data, t1.score, t1.title, t1.updated_at, t1.version, t1.views_distribution")
 	}
-	if fe.JoinNewsByID != nil && fe.JoinNewsByID.Fetch {
+	if fe.JoinNewsByID != nil && fe.JoinNewsByID.Kind.Actionable() && fe.JoinNewsByID.Fetch {
 		buf.WriteString(", t2.content, t2.continue, t2.created_at, t2.id, t2.lead, t2.meta_data, t2.score, t2.title, t2.updated_at, t2.version, t2.views_distribution")
 	}
 	buf.WriteString(" FROM ")
 	buf.WriteString(r.Table)
 	buf.WriteString(" AS t0")
-	if fe.JoinNewsByTitle != nil {
+	if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Kind.Actionable() {
 		joinClause(comp, fe.JoinNewsByTitle.Kind, "example.news AS t1 ON t0.news_title=t1.title")
 		if fe.JoinNewsByTitle.On != nil {
 			comp.Dirty = true
@@ -5282,7 +5282,7 @@ func (r *CommentRepositoryBase) FindQuery(fe *CommentFindExpr) (string, []interf
 			}
 		}
 	}
-	if fe.JoinNewsByID != nil {
+	if fe.JoinNewsByID != nil && fe.JoinNewsByID.Kind.Actionable() {
 		joinClause(comp, fe.JoinNewsByID.Kind, "example.news AS t2 ON t0.news_id=t2.id")
 		if fe.JoinNewsByID.On != nil {
 			comp.Dirty = true
@@ -5300,12 +5300,12 @@ func (r *CommentRepositoryBase) FindQuery(fe *CommentFindExpr) (string, []interf
 			return "", nil, err
 		}
 	}
-	if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Where != nil {
+	if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Kind.Actionable() && fe.JoinNewsByTitle.Where != nil {
 		if err := NewsCriteriaWhereClause(comp, fe.JoinNewsByTitle.Where, 1); err != nil {
 			return "", nil, err
 		}
 	}
-	if fe.JoinNewsByID != nil && fe.JoinNewsByID.Where != nil {
+	if fe.JoinNewsByID != nil && fe.JoinNewsByID.Kind.Actionable() && fe.JoinNewsByID.Where != nil {
 		if err := NewsCriteriaWhereClause(comp, fe.JoinNewsByID.Where, 2); err != nil {
 			return "", nil, err
 		}
@@ -5397,14 +5397,14 @@ func (r *CommentRepositoryBase) Find(ctx context.Context, fe *CommentFindExpr) (
 			return nil, err
 		}
 		var prop []interface{}
-		if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Fetch {
+		if fe.JoinNewsByTitle != nil && fe.JoinNewsByTitle.Kind.Actionable() && fe.JoinNewsByTitle.Fetch {
 			ent.NewsByTitle = &NewsEntity{}
 			if prop, err = ent.NewsByTitle.Props(); err != nil {
 				return nil, err
 			}
 			props = append(props, prop...)
 		}
-		if fe.JoinNewsByID != nil && fe.JoinNewsByID.Fetch {
+		if fe.JoinNewsByID != nil && fe.JoinNewsByID.Kind.Actionable() && fe.JoinNewsByID.Fetch {
 			ent.NewsByID = &NewsEntity{}
 			if prop, err = ent.NewsByID.Props(); err != nil {
 				return nil, err
@@ -9120,6 +9120,15 @@ func (jt JoinType) String() string {
 		return "CROSS JOIN"
 	default:
 		return ""
+	}
+}
+
+func (jt JoinType) Actionable() bool {
+	switch jt {
+	case JoinInner, JoinLeft, JoinRight, JoinCross:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/example/app/internal/model/schema_comment_test.go
+++ b/example/app/internal/model/schema_comment_test.go
@@ -215,7 +215,7 @@ func TestCommentRepositoryBase_FindIter(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	if len(got) != expected {
-		t.Errorf("wrong output, expected %d but got %d", expected, got)
+		t.Errorf("wrong output, expected %d but got %v", expected, got)
 	}
 }
 

--- a/example/app/internal/model/schema_news_test.go
+++ b/example/app/internal/model/schema_news_test.go
@@ -107,7 +107,7 @@ func TestNewsRepositoryBase_Insert(t *testing.T) {
 				t.Errorf("wrong title, expected %s but got %s", given.entity.Title, got.Title)
 			}
 			if given.entity.Lead != got.Lead {
-				t.Errorf("wrong lead, expected %s but got %s", given.entity.Lead, got.Lead)
+				t.Errorf("wrong lead, expected %v but got %v", given.entity.Lead, got.Lead)
 			}
 			if given.entity.Content != got.Content {
 				t.Errorf("wrong content, expected %s but got %s", given.entity.Content, got.Content)
@@ -280,7 +280,7 @@ func TestNewsRepositoryBase_Find(t *testing.T) {
 	}
 
 	if len(got) != expected {
-		t.Errorf("wrong output, expected %d but got %d", expected, got)
+		t.Errorf("wrong output, expected %d but got %v", expected, got)
 	}
 }
 
@@ -313,7 +313,7 @@ func TestNewsRepositoryBase_FindIter(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	if len(got) != expected {
-		t.Errorf("wrong output, expected %d but got %d", expected, got)
+		t.Errorf("wrong output, expected %d but got %v", expected, got)
 	}
 }
 
@@ -504,7 +504,7 @@ func TestNewsRepositoryBase_UpdateOneByID(t *testing.T) {
 			}
 			if given.entity.Lead.Valid {
 				if !strings.Contains(got.Lead.String, "(edited)") {
-					t.Errorf("wrong lead, should contains 'edited' but got %s", got.Lead)
+					t.Errorf("wrong lead, should contains 'edited' but got %v", got.Lead)
 				}
 			}
 			if !got.UpdatedAt.Valid {

--- a/example/app/internal/model/schema_package_test.go
+++ b/example/app/internal/model/schema_package_test.go
@@ -92,10 +92,10 @@ func TestPackageRepositoryBase_Insert(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
 			if given.entity.Break != got.Break {
-				t.Errorf("wrong break, expected %s but got %s", given.entity.Break, got.Break)
+				t.Errorf("wrong break, expected %v but got %v", given.entity.Break, got.Break)
 			}
 			if given.entity.CategoryID != got.CategoryID {
-				t.Errorf("wrong category id, expected %s but got %s", given.entity.CategoryID, got.CategoryID)
+				t.Errorf("wrong category id, expected %v but got %v", given.entity.CategoryID, got.CategoryID)
 			}
 			if !given.entity.UpdatedAt.Valid && got.UpdatedAt.Valid {
 				t.Error("updated at expected to be invalid")
@@ -245,7 +245,7 @@ func TestPackageRepositoryBase_Find(t *testing.T) {
 	}
 
 	if len(got) != expected {
-		t.Errorf("wrong output, expected %d but got %d", expected, got)
+		t.Errorf("wrong output, expected %d but got %v", expected, got)
 	}
 }
 
@@ -273,7 +273,7 @@ func TestPackageRepositoryBase_FindIter(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	if len(got) != expected {
-		t.Errorf("wrong output, expected %d but got %d", expected, got)
+		t.Errorf("wrong output, expected %d but got %v", expected, got)
 	}
 }
 
@@ -413,7 +413,7 @@ func TestPackageRepositoryBase_UpdateOneByID(t *testing.T) {
 
 			if given.entity.Break.Valid {
 				if !strings.Contains(got.Break.String, "(edited)") {
-					t.Errorf("wrong break, should contains 'edited' but got %s", got.Break)
+					t.Errorf("wrong break, should contains 'edited' but got %v", got.Break)
 				}
 			}
 			if !got.UpdatedAt.Valid {

--- a/internal/gogen/gen_general.go
+++ b/internal/gogen/gen_general.go
@@ -604,6 +604,15 @@ func (jt JoinType) String() string {
 	}
 }
 
+func (jt JoinType) Actionable() bool {
+	switch jt {
+	case JoinInner, JoinLeft, JoinRight, JoinCross:
+		return true
+	default:
+		return false
+	}
+}
+
 // ErrorConstraint returns the error constraint of err if it was produced by the pq library.
 // Otherwise, it returns empty string.
 func ErrorConstraint(err error) string {

--- a/internal/gogen/gen_general_test.go
+++ b/internal/gogen/gen_general_test.go
@@ -423,7 +423,7 @@ func (i *T2Iterator) T2() (*T2Entity, error) {
 		return nil, err
 	}
 	var prop []interface{}
-	if i.expr.JoinT1 != nil && i.expr.JoinT1.Fetch {
+	if i.expr.JoinT1 != nil && i.expr.JoinT1.Kind.Actionable() && i.expr.JoinT1.Fetch {
 		ent.T1 = &T1Entity{}
 		if prop, err = ent.T1.Props(); err != nil {
 			return nil, err

--- a/internal/gogen/gen_repository_find_test.go
+++ b/internal/gogen/gen_repository_find_test.go
@@ -73,13 +73,13 @@ func (r *T2RepositoryBase) FindQuery(fe *T2FindExpr) (string, []interface{}, err
 	} else {
 		buf.WriteString(strings.Join(fe.Columns, ", "))
 	}
-	if fe.JoinT1 != nil && fe.JoinT1.Fetch {
+	if fe.JoinT1 != nil && fe.JoinT1.Kind.Actionable() && fe.JoinT1.Fetch {
 		buf.WriteString(", t1.age, t1.id")
 	}
 	buf.WriteString(" FROM ")
 	buf.WriteString(r.Table)
 	buf.WriteString(" AS t0")
-	if fe.JoinT1 != nil {
+	if fe.JoinT1 != nil && fe.JoinT1.Kind.Actionable(){
 		joinClause(comp, fe.JoinT1.Kind, "t1 AS t1 ON t0.t1_id=t1.id")
 		if fe.JoinT1.On != nil {
 			comp.Dirty = true
@@ -97,7 +97,7 @@ func (r *T2RepositoryBase) FindQuery(fe *T2FindExpr) (string, []interface{}, err
 			return "", nil, err
 		}
 	}
-	if fe.JoinT1 != nil && fe.JoinT1.Where != nil {
+	if fe.JoinT1 != nil && fe.JoinT1.Kind.Actionable() && fe.JoinT1.Where != nil {
 		if err := T1CriteriaWhereClause(comp, fe.JoinT1.Where, 1); err != nil {
 			return "", nil, err
 		}

--- a/pqtgo/pqtgogen/generator_test.go
+++ b/pqtgo/pqtgogen/generator_test.go
@@ -1048,14 +1048,14 @@ var expectedSimple = `package example
     				return nil, err
     			}
     			var prop []interface{}
-    			if i.expr.JoinUser != nil && i.expr.JoinUser.Fetch {
+    			if i.expr.JoinUser != nil && i.expr.JoinUser.Kind.Actionable() && i.expr.JoinUser.Fetch {
     				ent.User = &UserEntity{}
     				if prop, err = ent.User.Props(); err != nil {
     					return nil, err
     				}
     				props = append(props, prop...)
     			}
-    			if i.expr.JoinWpis != nil && i.expr.JoinWpis.Fetch {
+    			if i.expr.JoinWpis != nil && i.expr.JoinWpis.Kind.Actionable() && i.expr.JoinWpis.Fetch {
     				ent.Wpis = &PostEntity{}
     				if prop, err = ent.Wpis.Props(); err != nil {
     					return nil, err
@@ -1274,16 +1274,16 @@ var expectedSimple = `package example
     			} else {
     				buf.WriteString(strings.Join(fe.Columns, ", "))
     			}
-    			if fe.JoinUser != nil && fe.JoinUser.Fetch {
+    			if fe.JoinUser != nil && fe.JoinUser.Kind.Actionable() && fe.JoinUser.Fetch {
     				buf.WriteString(", t1.id, t1.name")
     			}
-    			if fe.JoinWpis != nil && fe.JoinWpis.Fetch {
+    			if fe.JoinWpis != nil && fe.JoinWpis.Kind.Actionable() && fe.JoinWpis.Fetch {
     				buf.WriteString(", t2.body")
     			}
     			buf.WriteString(" FROM ")
     			buf.WriteString(r.Table)
     			buf.WriteString(" AS t0")
-    			if fe.JoinUser != nil {
+    			if fe.JoinUser != nil && fe.JoinUser.Kind.Actionable()  {
     				joinClause(comp, fe.JoinUser.Kind, "example.user AS t1 ON t0.user_id=t1.id")
     				if fe.JoinUser.On != nil {
     					comp.Dirty = true
@@ -1292,7 +1292,7 @@ var expectedSimple = `package example
     					}
     				}
     			}
-    			if fe.JoinWpis != nil {
+    			if fe.JoinWpis != nil && fe.JoinWpis.Kind.Actionable()  {
     				joinClause(comp, fe.JoinWpis.Kind, "post AS t2 ON ")
     				if fe.JoinWpis.On != nil {
     					comp.Dirty = true
@@ -1310,12 +1310,12 @@ var expectedSimple = `package example
     					return "", nil, err
     				}
     			}
-    			if fe.JoinUser != nil && fe.JoinUser.Where != nil {
+    			if fe.JoinUser != nil && fe.JoinUser.Kind.Actionable() && fe.JoinUser.Where != nil {
     				if err := UserCriteriaWhereClause(comp, fe.JoinUser.Where, 1); err != nil {
     					return "", nil, err
     				}
     			}
-    			if fe.JoinWpis != nil && fe.JoinWpis.Where != nil {
+    			if fe.JoinWpis != nil && fe.JoinWpis.Kind.Actionable() && fe.JoinWpis.Where != nil {
     				if err := PostCriteriaWhereClause(comp, fe.JoinWpis.Where, 2); err != nil {
     					return "", nil, err
     				}
@@ -1407,14 +1407,14 @@ var expectedSimple = `package example
     					return nil, err
     				}
     				var prop []interface{}
-    				if fe.JoinUser != nil && fe.JoinUser.Fetch {
+    				if fe.JoinUser != nil && fe.JoinUser.Kind.Actionable() && fe.JoinUser.Fetch {
     					ent.User = &UserEntity{}
     					if prop, err = ent.User.Props(); err != nil {
     						return nil, err
     					}
     					props = append(props, prop...)
     				}
-    				if fe.JoinWpis != nil && fe.JoinWpis.Fetch {
+    				if fe.JoinWpis != nil && fe.JoinWpis.Kind.Actionable() && fe.JoinWpis.Fetch {
     					ent.Wpis = &PostEntity{}
     					if prop, err = ent.Wpis.Props(); err != nil {
     						return nil, err
@@ -1603,6 +1603,15 @@ var expectedSimple = `package example
     				return ""
     			}
     		}
+
+			func (jt JoinType) Actionable() bool {
+				switch jt {
+				case JoinInner, JoinLeft, JoinRight, JoinCross:
+					return true
+				default:
+					return false
+				}
+			}
 
     		// ErrorConstraint returns the error constraint of err if it was produced by the pq library.
     		// Otherwise, it returns empty string.


### PR DESCRIPTION
`JoinType.Actionable` method that is used in FindQuery to decide if `JOIN` related code should be generated or not.